### PR TITLE
Add Unconditional socks5 Proxy Support

### DIFF
--- a/cmd/fuzz/help.go
+++ b/cmd/fuzz/help.go
@@ -120,7 +120,7 @@ The filters are evaluated in the following order. A response is displayed if:
 Proxy Configuration
 ###################
 
-A Proxy for HTTP and HTTPS requests can be configured serpartely via the environment
+A Proxy for HTTP and HTTPS requests can be configured separately via the environment
 variables HTTP_PROXY and HTTPS_PROXY. Both HTTP and socks5 proxies are supported:
 
     HTTP_PROXY=socks5://user:pass@proxyhost:123 monsoon fuzz [...]

--- a/cmd/fuzz/help.go
+++ b/cmd/fuzz/help.go
@@ -117,6 +117,15 @@ The filters are evaluated in the following order. A response is displayed if:
  * The header or body contain all show pattern (--show-pattern, if specified)
 
 
+Proxy Configuration
+###################
+
+A Proxy can be configured via the environment variables HTTP_PROXY, HTTPS_PROXY
+and SOCKS5_PROXY. Example:
+
+    SOCKS5_PROXY=user:pass@proxyhost:123 monsoon fuzz [...]
+
+
 References
 ##########
 

--- a/cmd/fuzz/help.go
+++ b/cmd/fuzz/help.go
@@ -120,11 +120,15 @@ The filters are evaluated in the following order. A response is displayed if:
 Proxy Configuration
 ###################
 
-A Proxy can be configured via the environment variables HTTP_PROXY, HTTPS_PROXY
-and SOCKS5_PROXY. Example:
+A Proxy for HTTP and HTTPS requests can be configured serpartely via the environment
+variables HTTP_PROXY and HTTPS_PROXY. Both HTTP and socks5 proxies are supported:
 
-    SOCKS5_PROXY=user:pass@proxyhost:123 monsoon fuzz [...]
+    HTTP_PROXY=socks5://user:pass@proxyhost:123 monsoon fuzz [...]
 
+Request to the loopback device are excluded from this proxy configuration. However,
+an unconditional socks5 server can be configured as follows:
+
+    FORCE_SOCKS5_PROXY=user:pass@proxyhost:123 monsoon fuzz [...]
 
 References
 ##########

--- a/cmd/test/help.go
+++ b/cmd/test/help.go
@@ -23,7 +23,7 @@ server at example.com and display the result:
       --value hunter2 \
       https://www.example.com
 
-A Proxy for HTTP and HTTPS requests can be configured serpartely via the environment
+A Proxy for HTTP and HTTPS requests can be configured separately via the environment
 variables HTTP_PROXY and HTTPS_PROXY. Both HTTP and socks5 proxies are supported:
 
     HTTP_PROXY=socks5://user:pass@proxyhost:123 monsoon fuzz [...]

--- a/cmd/test/help.go
+++ b/cmd/test/help.go
@@ -23,8 +23,13 @@ server at example.com and display the result:
       --value hunter2 \
       https://www.example.com
 
-A Proxy can be configured via the environment variables HTTP_PROXY, HTTPS_PROXY
-and SOCKS5_PROXY. Example:
+A Proxy for HTTP and HTTPS requests can be configured serpartely via the environment
+variables HTTP_PROXY and HTTPS_PROXY. Both HTTP and socks5 proxies are supported:
 
-    SOCKS5_PROXY=user:pass@proxyhost:123 monsoon fuzz [...]
+    HTTP_PROXY=socks5://user:pass@proxyhost:123 monsoon fuzz [...]
+
+Request to the loopback device are excluded from this proxy configuration. However,
+an unconditional socks5 server can be configured as follows:
+
+    FORCE_SOCKS5_PROXY=user:pass@proxyhost:123 monsoon fuzz [...]
 `

--- a/cmd/test/help.go
+++ b/cmd/test/help.go
@@ -22,4 +22,9 @@ server at example.com and display the result:
       --header "X-secret: FUZZ" \
       --value hunter2 \
       https://www.example.com
+
+A Proxy can be configured via the environment variables HTTP_PROXY, HTTPS_PROXY
+and SOCKS5_PROXY. Example:
+
+    SOCKS5_PROXY=user:pass@proxyhost:123 monsoon fuzz [...]
 `

--- a/response/runner.go
+++ b/response/runner.go
@@ -56,10 +56,12 @@ func NewTransport(insecure bool, TLSClientCertKeyFilename string, disableHTTP2 b
 
 	noProxy := len(os.Getenv("NO_PROXY")) > 0 || len(os.Getenv("no_proxy")) > 0
 
-	socks5ProxyConfig := os.Getenv("SOCKS5_PROXY")
+	socks5ProxyConfig := os.Getenv("FORCE_SOCKS5_PROXY")
 	if socks5ProxyConfig == "" || noProxy {
 		tr.DialContext = dialer.DialContext
 	} else {
+		// configure a socks5 proxy that also forwards requests
+		// to loopback devices through the proxy connection
 		socks5Dialer, err := socks5ContextDialer(dialer, socks5ProxyConfig)
 		if err != nil {
 			return nil, fmt.Errorf("configure socks5 proxy: %v", err)

--- a/response/runner.go
+++ b/response/runner.go
@@ -8,12 +8,15 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/RedTeamPentesting/monsoon/request"
 	"golang.org/x/net/http2"
+	"golang.org/x/net/proxy"
 )
 
 // Runner executes HTTP requests.
@@ -38,16 +41,31 @@ func NewTransport(insecure bool, TLSClientCertKeyFilename string, disableHTTP2 b
 	// for timeouts, see
 	// https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
 	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).Dial,
+		Proxy:                 http.ProxyFromEnvironment,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ResponseHeaderTimeout: 10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		IdleConnTimeout:       15 * time.Second,
 		TLSClientConfig:       &tls.Config{},
+	}
+
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+
+	noProxy := len(os.Getenv("NO_PROXY")) > 0 || len(os.Getenv("no_proxy")) > 0
+
+	socks5ProxyConfig := os.Getenv("SOCKS5_PROXY")
+	if socks5ProxyConfig == "" || noProxy {
+		tr.DialContext = dialer.DialContext
+	} else {
+		socks5Dialer, err := socks5ContextDialer(dialer, socks5ProxyConfig)
+		if err != nil {
+			return nil, fmt.Errorf("configure socks5 proxy: %v", err)
+		}
+
+		tr.DialContext = socks5Dialer.DialContext
 	}
 
 	if insecure {
@@ -76,6 +94,25 @@ func NewTransport(insecure bool, TLSClientCertKeyFilename string, disableHTTP2 b
 	}
 
 	return tr, nil
+}
+
+func socks5ContextDialer(dialer proxy.Dialer, socks5Conf string) (proxy.ContextDialer, error) {
+	socks5URL, err := url.Parse("socks5://" + socks5Conf)
+	if err != nil {
+		return nil, fmt.Errorf("parse socks5 configuration: %v", err)
+	}
+
+	socks5Dialer, err := proxy.FromURL(socks5URL, dialer)
+	if err != nil {
+		return nil, err
+	}
+
+	contextDialer, ok := socks5Dialer.(proxy.ContextDialer)
+	if !ok {
+		return nil, fmt.Errorf("socks5 dialer does not support context")
+	}
+
+	return contextDialer, nil
 }
 
 // readPEMCertKey reads a file and returns the PEM encoded certificate and key


### PR DESCRIPTION
This PR adds support for an unconditional socks5 proxy. `monsoon` already supported HTTP and socks5 proxies via `http.ProxyFromEnvironment`, but connections to loopback devices are excluded. Through the environment variable `FORCE_SOCKS5_PROXY` a socks5 server can be configured that also forwards requests to loopback devices. Username and password is supported and `$NO_PROXY` is also respected.

The help texts for the `fuzz` and `test` commands were modified to explain the possible proxy configuration options.

I also changed the `Dial` field of the `http.Transport` to `DialContext` because the former was deprecated.