### PR TITLE
Increase Connection Pool Limit to Avoid Resource Exhaustion

### DIFF
--- a/cmd/fuzz/main.go
+++ b/cmd/fuzz/main.go
@@ -319,7 +319,8 @@ func startRunners(ctx context.Context, opts *Options, in <-chan string) (<-chan 
 	out := make(chan response.Response)
 
 	var wg sync.WaitGroup
-	transport, err := response.NewTransport(opts.Request.Insecure, opts.Request.TLSClientKeyCertFile, opts.Request.DisableHTTP2)
+	transport, err := response.NewTransport(opts.Request.Insecure, opts.Request.TLSClientKeyCertFile,
+		opts.Request.DisableHTTP2, opts.Threads)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -115,7 +115,8 @@ func run(ctx context.Context, g *errgroup.Group, opts *Options, args []string) e
 
 	output := make(chan response.Response, 1)
 
-	tr, err := response.NewTransport(opts.Request.Insecure, opts.Request.TLSClientKeyCertFile, opts.Request.DisableHTTP2)
+	tr, err := response.NewTransport(opts.Request.Insecure, opts.Request.TLSClientKeyCertFile,
+		opts.Request.DisableHTTP2, 1)
 	if err != nil {
 		return err
 	}

--- a/response/runner.go
+++ b/response/runner.go
@@ -48,6 +48,8 @@ func NewTransport(insecure bool, TLSClientCertKeyFilename string, disableHTTP2 b
 		ExpectContinueTimeout: 1 * time.Second,
 		IdleConnTimeout:       15 * time.Second,
 		TLSClientConfig:       &tls.Config{},
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
 	}
 
 	if insecure {

--- a/response/runner.go
+++ b/response/runner.go
@@ -34,7 +34,8 @@ type Runner struct {
 const DefaultBodyBufferSize = 5 * 1024 * 1024
 
 // NewTransport creates a new shared transport for clients to use.
-func NewTransport(insecure bool, TLSClientCertKeyFilename string, disableHTTP2 bool) (*http.Transport, error) {
+func NewTransport(insecure bool, TLSClientCertKeyFilename string,
+	disableHTTP2 bool, concurrentRequests int) (*http.Transport, error) {
 	// for timeouts, see
 	// https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
 	tr := &http.Transport{
@@ -48,8 +49,8 @@ func NewTransport(insecure bool, TLSClientCertKeyFilename string, disableHTTP2 b
 		ExpectContinueTimeout: 1 * time.Second,
 		IdleConnTimeout:       15 * time.Second,
 		TLSClientConfig:       &tls.Config{},
-		MaxIdleConns:          100,
-		MaxIdleConnsPerHost:   100,
+		MaxIdleConns:          concurrentRequests,
+		MaxIdleConnsPerHost:   concurrentRequests,
 	}
 
 	if insecure {


### PR DESCRIPTION
The current HTTP transport limits the idle connections for pooling to 2 (`MaxIdleConns` is unlimited but `MaxIdleConnsPerHost` is `DefaultMaxIdleConnsPerHost=2`) . In the default configuration, `monsoon` will already do 5 concurrent requests which causes the limit to be exceeded and connections to be closed and reopened unnecessarily.

As this closing and reopening keeps happening over the lifetime of the scan, the operating system will keep the ephemeral ports of the countless closed connections in a `TIME_WAIT` state for some time. This can then easily cause the system to accumulate ports in this state until it exceeds its limits (on macOS this causes the error `can't assign requested address`).

This PR sets `MaxIdleConnsPerHost` and `DefaultMaxIdleConnsPerHost` to 100. The same solution was already applied to `gobuster` (see https://github.com/OJ/gobuster/issues/127 and https://github.com/OJ/gobuster/pull/140). The problem is also described in detail in [this blog post](https://tleyden.github.io/blog/2016/11/21/tuning-the-go-http-client-library-for-load-testing/), which suggests the same solution.

Another solution would be to take the number of "threads" as an argument and set it as the limit. This is what https://github.com/rakyll/hey does.