### PR TITLE
fix: Read response body more efficiently

### DIFF
--- a/cmd/fuzz/main.go
+++ b/cmd/fuzz/main.go
@@ -52,11 +52,11 @@ type Options struct {
 	ShowPattern     []string
 	showPattern     []*regexp.Regexp
 
-	Extract        []string
-	extract        []*regexp.Regexp
-	ExtractPipe    []string
-	extractPipe    [][]string
-	BodyBufferSize int
+	Extract           []string
+	extract           []*regexp.Regexp
+	ExtractPipe       []string
+	extractPipe       [][]string
+	MaxBodyBufferSize int
 }
 
 var opts Options
@@ -176,7 +176,7 @@ func AddCommand(c *cobra.Command) {
 
 	fs.StringArrayVar(&opts.Extract, "extract", nil, "extract `regex` from response body (can be specified multiple times)")
 	fs.StringArrayVar(&opts.ExtractPipe, "extract-pipe", nil, "pipe response body to `cmd` to extract data (can be specified multiple times)")
-	fs.IntVar(&opts.BodyBufferSize, "body-buffer-size", 5, "use `n` MiB as the buffer size for extracting strings from a response body")
+	fs.IntVar(&opts.MaxBodyBufferSize, "max-body-buffer-size", 5, "use `n` MiB as the maximum buffer size for extracting strings from a response body")
 }
 
 // logfilePath returns the prefix for the logfiles, if any.
@@ -327,7 +327,7 @@ func startRunners(ctx context.Context, opts *Options, in <-chan string) (<-chan 
 
 	for i := 0; i < opts.Threads; i++ {
 		runner := response.NewRunner(transport, opts.Request, in, out)
-		runner.BodyBufferSize = opts.BodyBufferSize * 1024 * 1024
+		runner.MaxBodyBufferSize = opts.MaxBodyBufferSize * 1024 * 1024
 		runner.Extract = opts.extract
 
 		runner.Client.CheckRedirect = func(req *http.Request, via []*http.Request) error {

--- a/response/runner.go
+++ b/response/runner.go
@@ -23,8 +23,8 @@ import (
 type Runner struct {
 	Template *request.Request
 
-	BodyBufferSize int
-	Extract        []*regexp.Regexp
+	MaxBodyBufferSize int
+	Extract           []*regexp.Regexp
 
 	Client    *http.Client
 	Transport *http.Transport
@@ -33,8 +33,9 @@ type Runner struct {
 	output chan<- Response
 }
 
-// DefaultBodyBufferSize is the default size for peeking at the body to extract strings via regexp.
-const DefaultBodyBufferSize = 5 * 1024 * 1024
+// DefaultMaxBodyBufferSize is the default maximum size for peeking at the body
+// to extract strings via regexp.
+const DefaultMaxBodyBufferSize = 5 * 1024 * 1024
 
 // NewTransport creates a new shared transport for clients to use.
 func NewTransport(insecure bool, TLSClientCertKeyFilename string,
@@ -164,12 +165,12 @@ func NewRunner(tr *http.Transport, template *request.Request, input <-chan strin
 	}
 
 	return &Runner{
-		Template:       template,
-		Client:         c,
-		Transport:      tr,
-		input:          input,
-		output:         output,
-		BodyBufferSize: DefaultBodyBufferSize,
+		Template:          template,
+		Client:            c,
+		Transport:         tr,
+		input:             input,
+		output:            output,
+		MaxBodyBufferSize: DefaultMaxBodyBufferSize,
 	}
 }
 
@@ -193,7 +194,7 @@ func (r *Runner) request(ctx context.Context, item string) (response Response) {
 		return
 	}
 
-	err = response.ReadBody(res.Body, r.BodyBufferSize)
+	err = response.ReadBody(res.Body, r.MaxBodyBufferSize)
 	if err != nil {
 		response.Error = err
 		return


### PR DESCRIPTION
This PR removes the (for most request unnecessary) allocation of 5MB for the response body per request.

I tested this with a 45k-lines wordlist against a local HTTPS test server in Go that returns a random status code and small response bodies:

|Branch | Requests/s | Time|
|-|-|-|
|Current Master|1811|19s|
|This PR|11947|3s|